### PR TITLE
お気に入り登録操作がajaxで完結するようにする＆アバターの対応アイテム一覧部分にお気に入り登録ボタンを表示

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -211,6 +211,8 @@ def avatar(request, avatar_id=1, page=1, sort_latest=False):
     params = {}
     user = request.user
     avatar = Avatar.objects.get(avatar_id=avatar_id)
+    folder_fav_items = None
+    folder_want_items = None
     if user.is_authenticated:
         social = SocialAccount.objects.filter(user=user).first()
         params['social'] = social
@@ -230,6 +232,10 @@ def avatar(request, avatar_id=1, page=1, sort_latest=False):
         params['folders'] = folders
         params['folders_some_added'] = some_added
         params['folders_some_added_want'] = some_added_want
+        folder_fav_items = dict(
+            [(folder, folder.fav_item.all()) for folder in folders])
+        folder_want_items = dict(
+            [(folder, folder.want_item.all()) for folder in folders])
     page = int(request.GET.get('page', page))
     sort_latest = request.GET.get('sort_latest', sort_latest)
     params['sort_latest'] = sort_latest
@@ -257,6 +263,20 @@ def avatar(request, avatar_id=1, page=1, sort_latest=False):
         if Customer.objects.filter(highlight=normal_item.creator):
             print("hit")
             setattr(normal_item, 'isHighlight', True)
+    if folder_fav_items:
+        for item in genuine_items:
+            setattr(item, 'folders_owned', set(
+                filter(lambda folder: item in folder_fav_items[folder], folders)))
+        for item in normal_items:
+            setattr(item, 'folders_owned', set(
+                filter(lambda folder: item in folder_fav_items[folder], folders)))
+    if folder_want_items:
+        for item in genuine_items:
+            setattr(item, 'folders_wanted', set(
+                filter(lambda folder: item in folder_want_items[folder], folders)))
+        for item in normal_items:
+            setattr(item, 'folders_wanted', set(
+                filter(lambda folder: item in folder_want_items[folder], folders)))
     params.update({
         'page': page,
         'avatar': avatar,

--- a/static/folder_form.js
+++ b/static/folder_form.js
@@ -5,8 +5,8 @@ document.addEventListener("DOMContentLoaded", () => {
      * @param {HTMLDivElement} $container 
      */
     function setupButtonContainer($container) {
-        const $parentButton = /** @type {HTMLButtonElement} */($container.querySelector(".list_folder_button"));
-        const $forms = /** @type {NodeListOf<HTMLFormElement>} */($container.querySelectorAll(".list_folder_form"));
+        const $parentButton = /** @type {HTMLButtonElement} */($container.querySelector(".folder_button"));
+        const $forms = /** @type {NodeListOf<HTMLFormElement>} */($container.querySelectorAll(".folder_form"));
 
         for (let i = 0; i < $forms.length; i++) {
             const $form = $forms[i];
@@ -40,7 +40,7 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
 
-    const $containers = /** @type {NodeListOf<HTMLDivElement>} */(document.querySelectorAll(".list_folder_button_container"));
+    const $containers = /** @type {NodeListOf<HTMLDivElement>} */(document.querySelectorAll(".folder_button_container"));
     for (let i = 0; i < $containers.length; i++) {
         setupButtonContainer($containers[i]);
     }

--- a/static/list_folder_form.js
+++ b/static/list_folder_form.js
@@ -1,21 +1,47 @@
 // @ts-check
 
 document.addEventListener("DOMContentLoaded", () => {
-    const $forms = /** @type {NodeListOf<HTMLFormElement>} */(document.querySelectorAll(".list_folder_form"));
-    for (let i = 0; i < $forms.length; i++) {
-        const $form = $forms[i];
-        $form.onsubmit = (e) => {
-            e.preventDefault();
-            const url = $form.action;
-            const csrfmiddlewaretoken = /** @type {HTMLInputElement} */($form.querySelector("input[name=csrfmiddlewaretoken]")).value;
-            const $button = /** @type {HTMLButtonElement} */($form.querySelector("button"));
-            const paramName = $button.name;
-            const value = $button.value;
-            const body = new FormData();
-            body.append("csrfmiddlewaretoken", csrfmiddlewaretoken);
-            body.append(paramName, value);
-            fetch(url, { method: 'POST', body }).then(() => window.location.reload());
-            return false;
-        };
+    /**
+     * @param {HTMLDivElement} $container 
+     */
+    function setupButtonContainer($container) {
+        const $parentButton = /** @type {HTMLButtonElement} */($container.querySelector(".list_folder_button"));
+        const $forms = /** @type {NodeListOf<HTMLFormElement>} */($container.querySelectorAll(".list_folder_form"));
+
+        for (let i = 0; i < $forms.length; i++) {
+            const $form = $forms[i];
+            $form.onsubmit = (e) => {
+                e.preventDefault();
+                const url = $form.action;
+                const csrfmiddlewaretoken = /** @type {HTMLInputElement} */($form.querySelector("input[name=csrfmiddlewaretoken]")).value;
+                const $button = /** @type {HTMLButtonElement} */($form.querySelector("button"));
+                const paramName = $button.name;
+                const value = $button.value;
+                const body = new FormData();
+                body.append("csrfmiddlewaretoken", csrfmiddlewaretoken);
+                body.append(paramName, value);
+                fetch(url, { method: 'POST', body }).then(() => {
+                    $parentButton.classList.remove("button");
+                    $parentButton.classList.add("button_already");
+                    $parentButton.textContent = (/** @type {string} */($parentButton.textContent)).replace("+", "✔ ");
+
+                    const $parent = /** @type {HTMLAnchorElement} */($form.parentElement);
+
+                    $parent.removeChild($form);
+
+                    const $addedButton = document.createElement("button");
+                    $addedButton.classList.add("button_already");
+                    $addedButton.disabled = true;
+                    $addedButton.textContent = "Added";
+                    $parent.prepend($addedButton);
+                });
+                return false;
+            };
+        }
+    }
+
+    const $containers = /** @type {NodeListOf<HTMLDivElement>} */(document.querySelectorAll(".list_folder_button_container"));
+    for (let i = 0; i < $containers.length; i++) {
+        setupButtonContainer($containers[i]);
     }
 });

--- a/static/style.css
+++ b/static/style.css
@@ -218,6 +218,18 @@ a:hover {
     font-weight: bold;
 }
 
+.thumbnail_box_folder_button_container
+{
+    display: inline-block;
+}
+
+.thumbnail_box_folder_button_container .button_already,
+.thumbnail_box_folder_button_container .button
+{
+    font-size: .8rem;
+    padding: .2rem;
+}
+
 .danger {
     font-size: 20px;
     border-radius: 5px;

--- a/templates/avatar.html
+++ b/templates/avatar.html
@@ -101,7 +101,7 @@
                     <a href="{% url 'app:item' item_id=item.item_id %}">
                         <img alt="thumb" src="{{ item.imageURL }}" class="thumb" />
                     </a>
-                    <p>
+                    <div>
                         <a href="{% url 'app:item' item_id=item.item_id %}">{{ item|truncatechars:30 }}</a>
                         by
                         <a href="{% url 'app:creator' creator_id=item.creator.creator_id %}">{{ item.creator|truncatechars:30 }}</a>
@@ -114,7 +114,81 @@
                         <a href="https://booth.pm/ja/items/{{ item.item_id }}" target="blank">
                             <img alt="emoji" class="emoji" src="{% static 'BOOTH_emoji.png' %}"  />
                         </a>
-                    </p>
+
+
+                        {% if user.is_authenticated %}
+                            <div class="folder_button_container thumbnail_box_folder_button_container btn-group dropright">
+                                <button type="button"
+                                        class="folder_button btn btn-secondary dropdown-toggle {% if item.folders_wanted %}button_already{% else %}button{% endif %}"
+                                        data-toggle="dropdown"
+                                        aria-haspopup="true"
+                                        aria-expanded="false">
+                                    {% if item.folders_wanted %}
+                                        ✔ W
+                                    {% else %}
+                                        +W
+                                    {% endif %}
+                                </button>
+                                <div class="dropdown-menu">
+                                    <!-- Dropdown menu links -->
+                                    {% for folder in folders %}
+                                        <a class="dropdown-item"
+                                        href="{% url 'app:folder' pk=folder.pk %}"
+                                        style="display:inline;line-height:40px">
+                                            {% if folder not in item.folders_wanted %}
+                                                <form class="folder_form"
+                                                    method="post"
+                                                    style="display:inline"
+                                                    action="{% url 'app:item' item_id=item.item_id %}">
+                                                    {% csrf_token %}
+                                                    <button class="button" name="add_want" value="{{ folder.pk }}">+WANT</button>
+                                                </form>
+                                            {% else %}
+                                                <button class="button_already" disabled>Added</button>
+                                            {% endif %}
+                                            {{ folder }}
+                                        </a>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                            <div class="folder_button_container thumbnail_box_folder_button_container btn-group dropright">
+                                <button type="button"
+                                        class="folder_button btn btn-secondary dropdown-toggle {% if item.folders_owned %}button_already{% else %}button{% endif %}"
+                                        data-toggle="dropdown"
+                                        aria-haspopup="true"
+                                        aria-expanded="false"
+                                        >
+                                    {% if item.folders_owned %}
+                                        ✔ O
+                                    {% else %}
+                                        +O
+                                    {% endif %}
+                                </button>
+                                <div class="dropdown-menu">
+                                    <!-- Dropdown menu links -->
+                                    {% for folder in folders %}
+                                        <a class="dropdown-item"
+                                        href="{% url 'app:folder' pk=folder.pk %}"
+                                        style="display:inline;line-height:40px">
+                                            {% if folder not in item.folders_owned %}
+                                                <form class="folder_form"
+                                                    method="post"
+                                                    style="display:inline"
+                                                    action="{% url 'app:item' item_id=item.item_id %}">
+                                                    {% csrf_token %}
+                                                    <button class="button" name="add" value="{{ folder.pk }}">+OWNED</button>
+                                                </form>
+                                            {% else %}
+                                                <button class="button_already" disabled>Added</button>
+                                            {% endif %}
+                                            {{ folder }}
+                                        </a>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        {% endif %}
+
+                    </div>
                 </div>
             {% endfor %}
         </div>
@@ -173,7 +247,7 @@
                         <a href="{% url 'app:item' item_id=item.item_id %}">
                             <img alt="thumb" src="{{ item.imageURL }}" class="thumb" />
                         </a>
-                        <p>
+                        <div>
                             <a href="{% url 'app:item' item_id=item.item_id %}">{{ item|truncatechars:30 }}</a>
                             by
                             <a href="{% url 'app:creator' creator_id=item.creator.creator_id %}">{{ item.creator|truncatechars:30 }}</a>
@@ -186,7 +260,80 @@
                             <a href="https://booth.pm/ja/items/{{ item.item_id }}" target="blank">
                                 <img alt="emoji" class="emoji" src="{% static 'BOOTH_emoji.png' %}" />
                             </a>
-                        </p>
+
+                            {% if user.is_authenticated %}
+                                <div class="folder_button_container thumbnail_box_folder_button_container btn-group dropright">
+                                    <button type="button"
+                                            class="folder_button btn btn-secondary dropdown-toggle {% if item.folders_wanted %}button_already{% else %}button{% endif %}"
+                                            data-toggle="dropdown"
+                                            aria-haspopup="true"
+                                            aria-expanded="false">
+                                        {% if item.folders_wanted %}
+                                            ✔ W
+                                        {% else %}
+                                            +W
+                                        {% endif %}
+                                    </button>
+                                    <div class="dropdown-menu">
+                                        <!-- Dropdown menu links -->
+                                        {% for folder in folders %}
+                                            <a class="dropdown-item"
+                                            href="{% url 'app:folder' pk=folder.pk %}"
+                                            style="display:inline;line-height:40px">
+                                                {% if folder not in item.folders_wanted %}
+                                                    <form class="folder_form"
+                                                        method="post"
+                                                        style="display:inline"
+                                                        action="{% url 'app:item' item_id=item.item_id %}">
+                                                        {% csrf_token %}
+                                                        <button class="button" name="add_want" value="{{ folder.pk }}">+WANT</button>
+                                                    </form>
+                                                {% else %}
+                                                    <button class="button_already" disabled>Added</button>
+                                                {% endif %}
+                                                {{ folder }}
+                                            </a>
+                                        {% endfor %}
+                                    </div>
+                                </div>
+                                <div class="folder_button_container thumbnail_box_folder_button_container btn-group dropright">
+                                    <button type="button"
+                                            class="folder_button btn btn-secondary dropdown-toggle {% if item.folders_owned %}button_already{% else %}button{% endif %}"
+                                            data-toggle="dropdown"
+                                            aria-haspopup="true"
+                                            aria-expanded="false"
+                                            >
+                                        {% if item.folders_owned %}
+                                            ✔ O
+                                        {% else %}
+                                            +O
+                                        {% endif %}
+                                    </button>
+                                    <div class="dropdown-menu">
+                                        <!-- Dropdown menu links -->
+                                        {% for folder in folders %}
+                                            <a class="dropdown-item"
+                                            href="{% url 'app:folder' pk=folder.pk %}"
+                                            style="display:inline;line-height:40px">
+                                                {% if folder not in item.folders_owned %}
+                                                    <form class="folder_form"
+                                                        method="post"
+                                                        style="display:inline"
+                                                        action="{% url 'app:item' item_id=item.item_id %}">
+                                                        {% csrf_token %}
+                                                        <button class="button" name="add" value="{{ folder.pk }}">+OWNED</button>
+                                                    </form>
+                                                {% else %}
+                                                    <button class="button_already" disabled>Added</button>
+                                                {% endif %}
+                                                {{ folder }}
+                                            </a>
+                                        {% endfor %}
+                                    </div>
+                                </div>
+                            {% endif %}
+
+                        </div>
                     </div>
                 {% endfor %}
             </div>

--- a/templates/avatar.html
+++ b/templates/avatar.html
@@ -30,15 +30,10 @@
     {% if user.is_authenticated %}
         <div class="btn-group dropright">
             <button type="button"
-                    class="btn btn-secondary dropdown-toggle"
+                    class="btn btn-secondary dropdown-toggle {% if folders_some_added_want %}button_already{% else %}button{% endif %}"
                     data-toggle="dropdown"
                     aria-haspopup="true"
-                    aria-expanded="false"
-                    {% if folders_some_added_want %}
-                    style="background-color:white;color:lightpink;border: 2px solid lightpink;font-size:20px;font-weight:bold">
-                    {% else %}
-                    style="background-color:lightpink;border: 2px solid lightpink;font-size:20px;font-weight:bold">
-                    {% endif %}
+                    aria-expanded="false">
                 {% if folders_some_added_want %}
                 ✔ WANT
                 {% else %}
@@ -66,15 +61,10 @@
         </div>
         <div class="btn-group dropright">
             <button type="button"
-                    class="btn btn-secondary dropdown-toggle"
+                    class="btn btn-secondary dropdown-toggle {% if folders_some_added %}button_already{% else %}button{% endif %}"
                     data-toggle="dropdown"
                     aria-haspopup="true"
-                    aria-expanded="false"
-                    {% if folders_some_added %}
-                    style="background-color:white;color:lightpink;border: 2px solid lightpink;font-size:20px;font-weight:bold">
-                    {% else %}
-                    style="background-color:lightpink;border: 2px solid lightpink;font-size:20px;font-weight:bold">
-                    {% endif %}
+                    aria-expanded="false">
                 {% if folders_some_added %}
                 ✔ OWNED
                 {% else %}

--- a/templates/avatar.html
+++ b/templates/avatar.html
@@ -2,6 +2,7 @@
 {% block content %}
     {% load humanize %}
     {% load static %}
+    <script src="{% static 'list_folder_form.js' %}"></script>
     <h3 class="deco">Avatar Page</h3>
     <h3>{{ avatar }}</h3>
     <p>
@@ -28,9 +29,9 @@
            target="blank">BOOTH Link</a>
     </p>
     {% if user.is_authenticated %}
-        <div class="btn-group dropright">
+        <div class="list_folder_button_container btn-group dropright">
             <button type="button"
-                    class="btn btn-secondary dropdown-toggle {% if folders_some_added_want %}button_already{% else %}button{% endif %}"
+                    class="list_folder_button btn btn-secondary dropdown-toggle {% if folders_some_added_want %}button_already{% else %}button{% endif %}"
                     data-toggle="dropdown"
                     aria-haspopup="true"
                     aria-expanded="false">
@@ -47,7 +48,7 @@
                        href="{% url 'app:folder' pk=folder.pk %}"
                        style="display:inline;line-height:40px">
                        {% if folder.notadd_want %}
-                       <form method="post" style="display:inline">
+                       <form class="list_folder_form" method="post" style="display:inline">
                            {% csrf_token %}
                            <button class="button" name="add_want" value="{{ folder.pk }}">+WANT</button>
                         </form>
@@ -59,9 +60,9 @@
                 {% endfor %}
             </div>
         </div>
-        <div class="btn-group dropright">
+        <div class="list_folder_button_container btn-group dropright">
             <button type="button"
-                    class="btn btn-secondary dropdown-toggle {% if folders_some_added %}button_already{% else %}button{% endif %}"
+                    class="list_folder_button btn btn-secondary dropdown-toggle {% if folders_some_added %}button_already{% else %}button{% endif %}"
                     data-toggle="dropdown"
                     aria-haspopup="true"
                     aria-expanded="false">
@@ -78,7 +79,7 @@
                        href="{% url 'app:folder' pk=folder.pk %}"
                        style="display:inline;line-height:40px">
                         {% if folder.notadd %}
-                        <form method="post" style="display:inline">
+                        <form class="list_folder_form" method="post" style="display:inline">
                             {% csrf_token %}
                             <button class="button" name="add" value="{{ folder.pk }}">+OWNED</button>
                         </form>

--- a/templates/avatar.html
+++ b/templates/avatar.html
@@ -2,7 +2,7 @@
 {% block content %}
     {% load humanize %}
     {% load static %}
-    <script src="{% static 'list_folder_form.js' %}"></script>
+    <script src="{% static 'folder_form.js' %}"></script>
     <h3 class="deco">Avatar Page</h3>
     <h3>{{ avatar }}</h3>
     <p>
@@ -29,9 +29,9 @@
            target="blank">BOOTH Link</a>
     </p>
     {% if user.is_authenticated %}
-        <div class="list_folder_button_container btn-group dropright">
+        <div class="folder_button_container btn-group dropright">
             <button type="button"
-                    class="list_folder_button btn btn-secondary dropdown-toggle {% if folders_some_added_want %}button_already{% else %}button{% endif %}"
+                    class="folder_button btn btn-secondary dropdown-toggle {% if folders_some_added_want %}button_already{% else %}button{% endif %}"
                     data-toggle="dropdown"
                     aria-haspopup="true"
                     aria-expanded="false">
@@ -48,7 +48,7 @@
                        href="{% url 'app:folder' pk=folder.pk %}"
                        style="display:inline;line-height:40px">
                        {% if folder.notadd_want %}
-                       <form class="list_folder_form" method="post" style="display:inline">
+                       <form class="folder_form" method="post" style="display:inline">
                            {% csrf_token %}
                            <button class="button" name="add_want" value="{{ folder.pk }}">+WANT</button>
                         </form>
@@ -60,9 +60,9 @@
                 {% endfor %}
             </div>
         </div>
-        <div class="list_folder_button_container btn-group dropright">
+        <div class="folder_button_container btn-group dropright">
             <button type="button"
-                    class="list_folder_button btn btn-secondary dropdown-toggle {% if folders_some_added %}button_already{% else %}button{% endif %}"
+                    class="folder_button btn btn-secondary dropdown-toggle {% if folders_some_added %}button_already{% else %}button{% endif %}"
                     data-toggle="dropdown"
                     aria-haspopup="true"
                     aria-expanded="false">
@@ -79,7 +79,7 @@
                        href="{% url 'app:folder' pk=folder.pk %}"
                        style="display:inline;line-height:40px">
                         {% if folder.notadd %}
-                        <form class="list_folder_form" method="post" style="display:inline">
+                        <form class="folder_form" method="post" style="display:inline">
                             {% csrf_token %}
                             <button class="button" name="add" value="{{ folder.pk }}">+OWNED</button>
                         </form>

--- a/templates/avatars.html
+++ b/templates/avatars.html
@@ -2,7 +2,7 @@
 {% block content %}
     {% load humanize %}
     {% load static %}
-    <script src="{% static 'list_folder_form.js' %}"></script>
+    <script src="{% static 'folder_form.js' %}"></script>
     <h3 class="deco">Avatars List</h3>
     <form method="get" action="{% url 'app:avatars' %}">
         {{ form }}
@@ -48,9 +48,9 @@
                 </a>
                 {% if user.is_authenticated %}
                     <div>
-                        <div class="list_folder_button_container btn-group dropright">
+                        <div class="folder_button_container btn-group dropright">
                             <button type="button"
-                                    class="list_folder_button btn btn-secondary dropdown-toggle {% if avatar.folders_wanted %}button_already{% else %}button{% endif %}"
+                                    class="folder_button btn btn-secondary dropdown-toggle {% if avatar.folders_wanted %}button_already{% else %}button{% endif %}"
                                     data-toggle="dropdown"
                                     aria-haspopup="true"
                                     aria-expanded="false">
@@ -67,7 +67,7 @@
                                    href="{% url 'app:folder' pk=folder.pk %}"
                                    style="display:inline;line-height:40px">
                                     {% if not folder in avatar.folders_wanted %}
-                                        <form class="list_folder_form"
+                                        <form class="folder_form"
                                               method="post"
                                               style="display:inline"
                                               action="{% url 'app:avatar' avatar_id=avatar.avatar_id %}">
@@ -82,9 +82,9 @@
                             {% endfor %}
                         </div>
                     </div>
-                    <div class="list_folder_button_container btn-group dropright">
+                    <div class="folder_button_container btn-group dropright">
                         <button type="button"
-                                class="list_folder_button btn btn-secondary dropdown-toggle {% if avatar.folders_owned %}button_already{% else %}button{% endif %}"
+                                class="folder_button btn btn-secondary dropdown-toggle {% if avatar.folders_owned %}button_already{% else %}button{% endif %}"
                                 data-toggle="dropdown"
                                 aria-haspopup="true"
                                 aria-expanded="false">
@@ -101,7 +101,7 @@
                                href="{% url 'app:folder' pk=folder.pk %}"
                                style="display:inline;line-height:40px">
                                 {% if not folder in avatar.folders_owned %}
-                                    <form class="list_folder_form"
+                                    <form class="folder_form"
                                           method="post"
                                           style="display:inline"
                                           action="{% url 'app:avatar' avatar_id=avatar.avatar_id %}">

--- a/templates/avatars.html
+++ b/templates/avatars.html
@@ -48,9 +48,9 @@
                 </a>
                 {% if user.is_authenticated %}
                     <div>
-                        <div class="btn-group dropright">
+                        <div class="list_folder_button_container btn-group dropright">
                             <button type="button"
-                                    class="btn btn-secondary dropdown-toggle {% if avatar.folders_wanted %}button_already{% else %}button{% endif %}"
+                                    class="list_folder_button btn btn-secondary dropdown-toggle {% if avatar.folders_wanted %}button_already{% else %}button{% endif %}"
                                     data-toggle="dropdown"
                                     aria-haspopup="true"
                                     aria-expanded="false">
@@ -82,9 +82,9 @@
                             {% endfor %}
                         </div>
                     </div>
-                    <div class="btn-group dropright">
+                    <div class="list_folder_button_container btn-group dropright">
                         <button type="button"
-                                class="btn btn-secondary dropdown-toggle {% if avatar.folders_owned %}button_already{% else %}button{% endif %}"
+                                class="list_folder_button btn btn-secondary dropdown-toggle {% if avatar.folders_owned %}button_already{% else %}button{% endif %}"
                                 data-toggle="dropdown"
                                 aria-haspopup="true"
                                 aria-expanded="false">

--- a/templates/avatars.html
+++ b/templates/avatars.html
@@ -50,15 +50,10 @@
                     <div>
                         <div class="btn-group dropright">
                             <button type="button"
-                                    class="btn btn-secondary dropdown-toggle"
+                                    class="btn btn-secondary dropdown-toggle {% if avatar.folders_wanted %}button_already{% else %}button{% endif %}"
                                     data-toggle="dropdown"
                                     aria-haspopup="true"
-                                    aria-expanded="false"
-                                    {% if avatar.folders_wanted %}
-                                    style="background-color:white;color:lightpink;border: 2px solid lightpink;font-size:20px;font-weight:bold">
-                            {% else %}
-                                style="background-color:lightpink;border: 2px solid lightpink;font-size:20px;font-weight:bold">
-                            {% endif %}
+                                    aria-expanded="false">
                             {% if avatar.folders_wanted %}
                                 ✔ WANT
                             {% else %}
@@ -89,15 +84,10 @@
                     </div>
                     <div class="btn-group dropright">
                         <button type="button"
-                                class="btn btn-secondary dropdown-toggle"
+                                class="btn btn-secondary dropdown-toggle {% if avatar.folders_owned %}button_already{% else %}button{% endif %}"
                                 data-toggle="dropdown"
                                 aria-haspopup="true"
-                                aria-expanded="false"
-                                {% if avatar.folders_owned %}
-                                style="background-color:white;color:lightpink;border: 2px solid lightpink;font-size:20px;font-weight:bold">
-                        {% else %}
-                            style="background-color:lightpink;border: 2px solid lightpink;font-size:20px;font-weight:bold">
-                        {% endif %}
+                                aria-expanded="false">
                         {% if avatar.folders_owned %}
                             ✔ OWNED
                         {% else %}

--- a/templates/item.html
+++ b/templates/item.html
@@ -2,7 +2,7 @@
 {% block content %}
     {% load humanize %}
     {% load static %}
-    <script src="{% static 'list_folder_form.js' %}"></script>
+    <script src="{% static 'folder_form.js' %}"></script>
     <h3 class="deco">Item Page</h3>
     <h3>{{ item }}</h3>
     by
@@ -23,9 +23,9 @@
         <a href="https://booth.pm/ja/items/{{ item.item_id }}">BOOTH Link</a>
     </p>
     {% if user.is_authenticated %}
-        <div class="list_folder_button_container btn-group dropright">
+        <div class="folder_button_container btn-group dropright">
             <button type="button"
-                    class="list_folder_button btn btn-secondary dropdown-toggle {% if folders_some_added_want %}button_already{% else %}button{% endif %}"
+                    class="folder_button btn btn-secondary dropdown-toggle {% if folders_some_added_want %}button_already{% else %}button{% endif %}"
                     data-toggle="dropdown"
                     aria-haspopup="true"
                     aria-expanded="false">
@@ -42,7 +42,7 @@
                        href="{% url 'app:folder' pk=folder.pk %}"
                        style="display:inline;line-height:40px">
                         {% if folder.notadd_want %}
-                            <form class="list_folder_form" method="post" style="display:inline">
+                            <form class="folder_form" method="post" style="display:inline">
                                 {% csrf_token %}
                                 <button class="button" name="add_want" value="{{ folder.pk }}">+WANT</button>
                             </form>
@@ -54,9 +54,9 @@
                 {% endfor %}
             </div>
         </div>
-        <div class="list_folder_button_container btn-group dropright">
+        <div class="folder_button_container btn-group dropright">
             <button type="button"
-                    class="list_folder_button btn btn-secondary dropdown-toggle {% if folders_some_added %}button_already{% else %}button{% endif %}"
+                    class="folder_button btn btn-secondary dropdown-toggle {% if folders_some_added %}button_already{% else %}button{% endif %}"
                     data-toggle="dropdown"
                     aria-haspopup="true"
                     aria-expanded="false">
@@ -73,7 +73,7 @@
                        href="{% url 'app:folder' pk=folder.pk %}"
                        style="display:inline;line-height:40px">
                         {% if folder.notadd %}
-                            <form class="list_folder_form" method="post" style="display:inline">
+                            <form class="folder_form" method="post" style="display:inline">
                                 {% csrf_token %}
                                 <button class="button" name="add" value="{{ folder.pk }}">+OWNED</button>
                             </form>

--- a/templates/item.html
+++ b/templates/item.html
@@ -24,15 +24,10 @@
     {% if user.is_authenticated %}
         <div class="btn-group dropright">
             <button type="button"
-                    class="btn btn-secondary dropdown-toggle"
+                    class="btn btn-secondary dropdown-toggle {% if folders_some_added_want %}button_already{% else %}button{% endif %}"
                     data-toggle="dropdown"
                     aria-haspopup="true"
-                    aria-expanded="false"
-                    {% if folders_some_added_want %}
-                    style="background-color:white;color:lightpink;border: 2px solid lightpink;font-size:20px;font-weight:bold">
-                    {% else %}
-                    style="background-color:lightpink;border: 2px solid lightpink;font-size:20px;font-weight:bold">
-                    {% endif %}
+                    aria-expanded="false">
                 {% if folders_some_added_want %}
                 ✔ WANT
                 {% else %}
@@ -60,15 +55,10 @@
         </div>
         <div class="btn-group dropright">
             <button type="button"
-                    class="btn btn-secondary dropdown-toggle"
+                    class="btn btn-secondary dropdown-toggle {% if folders_some_added %}button_already{% else %}button{% endif %}"
                     data-toggle="dropdown"
                     aria-haspopup="true"
-                    aria-expanded="false"
-                    {% if folders_some_added %}
-                    style="background-color:white;color:lightpink;border: 2px solid lightpink;font-size:20px;font-weight:bold">
-                    {% else %}
-                    style="background-color:lightpink;border: 2px solid lightpink;font-size:20px;font-weight:bold">
-                    {% endif %}
+                    aria-expanded="false">
                 {% if folders_some_added %}
                 ✔ OWNED
                 {% else %}

--- a/templates/item.html
+++ b/templates/item.html
@@ -2,6 +2,7 @@
 {% block content %}
     {% load humanize %}
     {% load static %}
+    <script src="{% static 'list_folder_form.js' %}"></script>
     <h3 class="deco">Item Page</h3>
     <h3>{{ item }}</h3>
     by
@@ -22,9 +23,9 @@
         <a href="https://booth.pm/ja/items/{{ item.item_id }}">BOOTH Link</a>
     </p>
     {% if user.is_authenticated %}
-        <div class="btn-group dropright">
+        <div class="list_folder_button_container btn-group dropright">
             <button type="button"
-                    class="btn btn-secondary dropdown-toggle {% if folders_some_added_want %}button_already{% else %}button{% endif %}"
+                    class="list_folder_button btn btn-secondary dropdown-toggle {% if folders_some_added_want %}button_already{% else %}button{% endif %}"
                     data-toggle="dropdown"
                     aria-haspopup="true"
                     aria-expanded="false">
@@ -41,7 +42,7 @@
                        href="{% url 'app:folder' pk=folder.pk %}"
                        style="display:inline;line-height:40px">
                         {% if folder.notadd_want %}
-                            <form method="post" style="display:inline">
+                            <form class="list_folder_form" method="post" style="display:inline">
                                 {% csrf_token %}
                                 <button class="button" name="add_want" value="{{ folder.pk }}">+WANT</button>
                             </form>
@@ -53,9 +54,9 @@
                 {% endfor %}
             </div>
         </div>
-        <div class="btn-group dropright">
+        <div class="list_folder_button_container btn-group dropright">
             <button type="button"
-                    class="btn btn-secondary dropdown-toggle {% if folders_some_added %}button_already{% else %}button{% endif %}"
+                    class="list_folder_button btn btn-secondary dropdown-toggle {% if folders_some_added %}button_already{% else %}button{% endif %}"
                     data-toggle="dropdown"
                     aria-haspopup="true"
                     aria-expanded="false">
@@ -72,7 +73,7 @@
                        href="{% url 'app:folder' pk=folder.pk %}"
                        style="display:inline;line-height:40px">
                         {% if folder.notadd %}
-                            <form method="post" style="display:inline">
+                            <form class="list_folder_form" method="post" style="display:inline">
                                 {% csrf_token %}
                                 <button class="button" name="add" value="{{ folder.pk }}">+OWNED</button>
                             </form>

--- a/templates/items.html
+++ b/templates/items.html
@@ -47,15 +47,10 @@
                 {% if user.is_authenticated %}
                     <div class="btn-group dropright">
                         <button type="button"
-                                class="btn btn-secondary dropdown-toggle"
+                                class="btn btn-secondary dropdown-toggle {% if item.folders_wanted %}button_already{% else %}button{% endif %}"
                                 data-toggle="dropdown"
                                 aria-haspopup="true"
-                                aria-expanded="false"
-                                {% if item.folders_wanted %}
-                                style="background-color:white;color:lightpink;border: 2px solid lightpink;font-size:20px;font-weight:bold">
-                        {% else %}
-                            style="background-color:lightpink;border: 2px solid lightpink;font-size:20px;font-weight:bold">
-                        {% endif %}
+                                aria-expanded="false">
                         {% if item.folders_wanted %}
                             ✔ WANT
                         {% else %}
@@ -86,15 +81,11 @@
                 </div>
                 <div class="btn-group dropright">
                     <button type="button"
-                            class="btn btn-secondary dropdown-toggle"
+                            class="btn btn-secondary dropdown-toggle {% if item.folders_owned %}button_already{% else %}button{% endif %}"
                             data-toggle="dropdown"
                             aria-haspopup="true"
                             aria-expanded="false"
-                            {% if item.folders_owned %}
-                            style="background-color:white;color:lightpink;border: 2px solid lightpink;font-size:20px;font-weight:bold">
-                    {% else %}
-                        style="background-color:lightpink;border: 2px solid lightpink;font-size:20px;font-weight:bold">
-                    {% endif %}
+                            >
                     {% if item.folders_owned %}
                         ✔ OWNED
                     {% else %}

--- a/templates/items.html
+++ b/templates/items.html
@@ -2,7 +2,7 @@
 {% block content %}
     {% load humanize %}
     {% load static %}
-    <script src="{% static 'list_folder_form.js' %}"></script>
+    <script src="{% static 'folder_form.js' %}"></script>
     <h3 class="deco">Items List</h3>
     <form method="get" action="{% url 'app:items' %}">
         {{ form }}
@@ -45,9 +45,9 @@
                     </a>
                 </p>
                 {% if user.is_authenticated %}
-                    <div class="list_folder_button_container btn-group dropright">
+                    <div class="folder_button_container btn-group dropright">
                         <button type="button"
-                                class="list_folder_button btn btn-secondary dropdown-toggle {% if item.folders_wanted %}button_already{% else %}button{% endif %}"
+                                class="folder_button btn btn-secondary dropdown-toggle {% if item.folders_wanted %}button_already{% else %}button{% endif %}"
                                 data-toggle="dropdown"
                                 aria-haspopup="true"
                                 aria-expanded="false">
@@ -64,7 +64,7 @@
                                href="{% url 'app:folder' pk=folder.pk %}"
                                style="display:inline;line-height:40px">
                                 {% if folder not in item.folders_wanted %}
-                                    <form class="list_folder_form"
+                                    <form class="folder_form"
                                           method="post"
                                           style="display:inline"
                                           action="{% url 'app:item' item_id=item.item_id %}">
@@ -79,9 +79,9 @@
                         {% endfor %}
                     </div>
                 </div>
-                <div class="list_folder_button_container btn-group dropright">
+                <div class="folder_button_container btn-group dropright">
                     <button type="button"
-                            class="list_folder_button btn btn-secondary dropdown-toggle {% if item.folders_owned %}button_already{% else %}button{% endif %}"
+                            class="folder_button btn btn-secondary dropdown-toggle {% if item.folders_owned %}button_already{% else %}button{% endif %}"
                             data-toggle="dropdown"
                             aria-haspopup="true"
                             aria-expanded="false"
@@ -99,7 +99,7 @@
                            href="{% url 'app:folder' pk=folder.pk %}"
                            style="display:inline;line-height:40px">
                             {% if folder not in item.folders_owned %}
-                                <form class="list_folder_form"
+                                <form class="folder_form"
                                       method="post"
                                       style="display:inline"
                                       action="{% url 'app:item' item_id=item.item_id %}">

--- a/templates/items.html
+++ b/templates/items.html
@@ -45,9 +45,9 @@
                     </a>
                 </p>
                 {% if user.is_authenticated %}
-                    <div class="btn-group dropright">
+                    <div class="list_folder_button_container btn-group dropright">
                         <button type="button"
-                                class="btn btn-secondary dropdown-toggle {% if item.folders_wanted %}button_already{% else %}button{% endif %}"
+                                class="list_folder_button btn btn-secondary dropdown-toggle {% if item.folders_wanted %}button_already{% else %}button{% endif %}"
                                 data-toggle="dropdown"
                                 aria-haspopup="true"
                                 aria-expanded="false">
@@ -79,9 +79,9 @@
                         {% endfor %}
                     </div>
                 </div>
-                <div class="btn-group dropright">
+                <div class="list_folder_button_container btn-group dropright">
                     <button type="button"
-                            class="btn btn-secondary dropdown-toggle {% if item.folders_owned %}button_already{% else %}button{% endif %}"
+                            class="list_folder_button btn btn-secondary dropdown-toggle {% if item.folders_owned %}button_already{% else %}button{% endif %}"
                             data-toggle="dropdown"
                             aria-haspopup="true"
                             aria-expanded="false"


### PR DESCRIPTION
- 登録時にいちいち再読込されるのが特にリストでいらいらするので、ajaxによるその場書き換えにしました。
- アバターの対応アイテム一覧部分にお気に入り登録ボタンを表示しました。
  - 他の類似箇所にも付けたほうが良いと思うが、コンポーネントが共通化されていないのでとりあえず本サービス上最も使われそうなこの部分にいったん

イメージ（アバターとアイテムの対応はでたらめです）
![image](https://github.com/hibit-at/avatar_network/assets/1712548/86ee3801-8415-4b8c-b63a-6729439772e3)
