### PR TITLE
ヘッダのドロップダウンとそれを開くボタンの空間をなくす

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -299,6 +299,10 @@ a:hover {
     position: absolute;
 }
 
+.dropdown-menu {
+    margin-top: 0;
+}
+
 .dropdown:hover .dropdown-menu {
     display: block;
 }


### PR DESCRIPTION
- ログイン中のヘッダの右側のドロップダウン部分は、 Bootstrap のデフォルトのスタイルでは、ドロップダウンとそれを開くボタンに空間があります
  - `margin: 0.125rem 0 0;` となっていて、 2px 開いている
  - <img width="905" alt="image" src="https://github.com/hibit-at/avatar_network/assets/12870472/acec4685-b90a-41d2-8f43-50b8e4d164a2">
- ボタンからドロップダウンに向かってカーソルを動かしたときに、この空間の上にカーソルを動かしてしまうと、ドロップダウンが閉じてしまいます
  - カーソルを素早く動かすと、閉じられないままドロップダウンまでカーソルを動かせるものの、ゆっくり動かすと閉じてしまう
- この空間をなくすことで、常にボタン内をマウスホバーしている状態でカーソルをドロップダウンに動かせるようにしました
  - Bootstrap としては元々ボタンを押して (クリックして) ドロップダウンを開くことを想定されていそうでした (カーソルがどこに動いてもドロップダウンが開いたままになる)
  - このリポジトリ内では、ボタンにマウスホバーでドロップダウンを出すようにカスタマイズしているので、その使い方でもドロップダウンをスムーズに操作できるようにしたい、という変更です